### PR TITLE
Fix compatible with numpy 2.X

### DIFF
--- a/pygasflow/utils/common.py
+++ b/pygasflow/utils/common.py
@@ -8,9 +8,9 @@ def convert_to_ndarray(x):
     1 dimensional.
     """
     if not isinstance(x, np.ndarray):
-        return np.atleast_1d(np.array(x, copy=False, dtype=np.float64))
+        return np.atleast_1d(np.asarray(x, dtype=np.float64))
     if x.ndim == 0:
-        return np.atleast_1d(np.array(x, copy=False, dtype=np.float64))
+        return np.atleast_1d(np.asarray(x, dtype=np.float64))
     return x
 
 


### PR DESCRIPTION
I was having the following error while using the function conical_shockwave_solver, this appears to be due to the migration to numpy 2.X:

> Traceback (most recent call last):
>   File "n:\...\code_mur_1D_v3.py", line 43, in <module>
>     cone_res=pgf.conical_shockwave_solver(INITIAL_MACH, 'theta_c', WEDGE, GAMMA)
>              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "C:\Users\...\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\pygasflow\utils\decorators.py", line 232, in wrapper_function
>     args[i] = convert_to_ndarray(args[i])
>               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "C:\Users\...\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\pygasflow\utils\common.py", line 11, in convert_to_ndarray
>     return np.atleast_1d(np.array(x, copy=False, dtype=np.float64))
>                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> ValueError: Unable to avoid copy while creating an array as requested.
> If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).
> For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.

I apply this change `np.array(..., copy=False)` to `np.asarray(...)` to be compatible with numpy 2.X,
See: https://numpy.org/doc/stable/numpy_2_0_migration_guide.html