### PR TITLE
Fixed critical velocity ratio

### DIFF
--- a/pygasflow/isentropic.py
+++ b/pygasflow/isentropic.py
@@ -34,11 +34,7 @@ def critical_velocity_ratio(M, gamma=1.4):
     out : ndarray
         Critical velocity ratio U/U*.
     """
-    # need to deal with division by 0
-    ratio = np.zeros_like(M)
-    idx = M != 0
-    ratio[idx] = 1 / ((2 / (gamma + 1))**(1 / (gamma - 1)) / M[idx] * (1 + (gamma - 1) / 2 * M[idx]**2)**0.5)
-    return ratio
+    return M * ((gamma + 1) / (2 + (gamma - 1) * M**2)) ** 0.5
 
 
 @check


### PR DESCRIPTION
Fixes issue #10 

I used a different, but equivalent, formula to the one proposed by @hcliment that also avoids division by zero at M = 0. 

Here is my working out:
![lagrida_latex_editor](https://github.com/user-attachments/assets/7d5e5ff6-8945-4af8-a322-2c7e32f7c72d)

Here is a comparison with the existing formula and the formula offered by @hcliment:
<img width="640" height="480" alt="validation_graph" src="https://github.com/user-attachments/assets/1b572cc9-edb7-44f3-a8b6-af9e74ceb5ed" />
